### PR TITLE
Add initial Aldi Tab & some bottom margin for the custom tabbar

### DIFF
--- a/screens/home/components/SectionsTabBar.tsx
+++ b/screens/home/components/SectionsTabBar.tsx
@@ -13,7 +13,7 @@ interface Props {
 const STabBarContainer: ViewStyle = {
   flex: 0,
   backgroundColor: palette.white,
-  marginTop: 7,
+  marginVertical: 7,
 }
 
 const SectionsTabBar: FC<Props> = ({sections, activeSection, setActiveSection}) => {

--- a/screens/home/supportedSupermarkets.ts
+++ b/screens/home/supportedSupermarkets.ts
@@ -25,7 +25,12 @@ const supportedSupermarkets: TSupportedSupermarkets = {
   "Aldi S": {
     displayName: "Aldi S",
     logo: {logoName: "Aldi S", dimensions: [28, 28]},
-    sections: [{title: "", url: ""}],
+    sections: [
+      {title: "Frischekracher", url: "https://www.aldi-sued.de/de/angebote/frischekracher.html"},
+      {title: "Preisaktion", url: "https://www.aldi-sued.de/de/angebote/preisaktion.html"},
+      {title: "Markenaktion", url: "https://www.aldi-sued.de/de/angebote/markenaktion-der-woche.html"},
+      {title: "Prospekte", url: "https://www.aldi-sued.de/de/angebote/Prospekte.html"},
+    ],
   },
 }
 


### PR DESCRIPTION
- Adds Aldi relevant deal pages name and urls where added to supportedSupermarkets.ts
- Adds some bottom margin to the custom tabbar

![Screenshot from 2022-10-07 22-23-02](https://user-images.githubusercontent.com/56154553/194646891-b747f9e7-9e92-4cbe-b5d1-0228add7f0f5.png)
